### PR TITLE
Database::transact api is now generic and should be future proof.

### DIFF
--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -1362,7 +1362,7 @@ impl StackMachine {
                     Ok(())
                 }
                 let r = db
-                    .transact(
+                    .transact_boxed_local(
                         (begin, end),
                         |trx, (begin, end)| wait_for_empty(trx, begin, end).boxed_local(),
                         TransactOption::default(),

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "foundationdb"
 version = "0.4.0"
 authors = [
-    "Benjamin Fry <benjaminfry@me.com>", 
+    "Benjamin Fry <benjaminfry@me.com>",
     "Vincent Rouillé <vincent@clikengo.com>",
 ]
 edition = "2018"
@@ -47,3 +47,4 @@ uuid = { version = "0.8.1", optional = true }
 byteorder = "1.3.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
+tokio = { version = "0.2.9", features = ["rt-core"] }

--- a/foundationdb/examples/class-scheduling.rs
+++ b/foundationdb/examples/class-scheduling.rs
@@ -153,7 +153,7 @@ async fn ditch_trx(trx: &Transaction, student: &str, class: &str) {
 }
 
 async fn ditch(db: &Database, student: String, class: String) -> Result<()> {
-    db.transact(
+    db.transact_boxed_local(
         (student, class),
         move |trx, (student, class)| ditch_trx(trx, student, class).map(|_| Ok(())).boxed_local(),
         fdb::TransactOption::default(),
@@ -205,7 +205,7 @@ async fn signup_trx(trx: &Transaction, student: &str, class: &str) -> Result<()>
 }
 
 async fn signup(db: &Database, student: String, class: String) -> Result<()> {
-    db.transact(
+    db.transact_boxed_local(
         (student, class),
         |trx, (student, class)| signup_trx(&trx, student, class).boxed_local(),
         TransactOption::default(),
@@ -230,7 +230,7 @@ async fn switch_classes(
         Ok(())
     }
 
-    db.transact(
+    db.transact_boxed_local(
         (student_id, old_class, new_class),
         move |trx, (student_id, old_class, new_class)| {
             switch_classes_body(trx, student_id, old_class, new_class).boxed_local()

--- a/foundationdb/tests/common/mod.rs
+++ b/foundationdb/tests/common/mod.rs
@@ -25,6 +25,7 @@ pub fn boot() {
     let _end = &*ENV;
 }
 
+#[allow(unused)]
 pub async fn database() -> fdb::FdbResult<fdb::Database> {
     fdb::Database::new_compat(None).await
 }

--- a/foundationdb/tests/future.rs
+++ b/foundationdb/tests/future.rs
@@ -39,7 +39,7 @@ fn test_future_discard() {
 async fn test_future_discard_async() -> FdbResult<()> {
     let db = common::database().await?;
     for _i in 0..=1000 {
-        db.transact(
+        db.transact_boxed_local(
             (),
             |trx, ()| {
                 AbortingFuture {

--- a/foundationdb/tests/get.rs
+++ b/foundationdb/tests/get.rs
@@ -146,7 +146,7 @@ async fn test_transact_async() -> FdbResult<()> {
     let try_count = Arc::new(AtomicUsize::new(0));
     let db = common::database().await?;
     let res = db
-        .transact(
+        .transact_boxed(
             &db,
             |trx, db| async_body(db, trx, try_count.clone()).boxed(),
             TransactOption::default(),

--- a/foundationdb/tests/hca.rs
+++ b/foundationdb/tests/hca.rs
@@ -72,7 +72,7 @@ async fn test_hca_concurrent_allocations_async() -> FdbResult<()> {
     let hca = HighContentionAllocator::new(Subspace::from_bytes(KEY));
 
     let all_ints: Vec<i64> = future::try_join_all((0..N).map(|_| {
-        db.transact(
+        db.transact_boxed_local(
             &hca,
             move |tx, hca| hca.allocate(tx).boxed_local(),
             TransactOption::default(),

--- a/foundationdb/tests/tokio.rs
+++ b/foundationdb/tests/tokio.rs
@@ -1,0 +1,57 @@
+use foundationdb::*;
+use futures::prelude::*;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+mod common;
+
+#[test]
+// dropping a future while it's in the pending state should not crash
+fn test_tokio_send() {
+    common::boot();
+
+    let mut rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        do_transact().await;
+        do_trx().await;
+    });
+}
+async fn do_transact() {
+    let db = Arc::new(
+        foundationdb::Database::new_compat(None)
+            .await
+            .expect("failed to open fdb"),
+    );
+
+    let adb = db.clone();
+    tokio::spawn(async move {
+        async fn txnfn(_txn: &Transaction) -> FdbResult<()> {
+            Ok(())
+        }
+
+        adb.transact_boxed(
+            (),
+            |txn: &Transaction, ()| txnfn(txn).boxed(),
+            TransactOption::default(),
+        )
+        .await
+        .expect("failed to transact")
+    });
+}
+
+async fn do_trx() {
+    let db = Arc::new(
+        foundationdb::Database::new_compat(None)
+            .await
+            .expect("failed to open fdb"),
+    );
+
+    let adb = db.clone();
+    tokio::spawn(async move {
+        adb.create_trx()
+            .expect("failed to create trx")
+            .commit()
+            .await
+            .expect("failed to commit");
+    });
+}


### PR DESCRIPTION
It took me a while, but I think I managed to get a future proof trait for Database::transact.

For now the expected entry point is `transact_boxed` and `transact_boxed_local`.
Once GAT and or async trait land in stable rust, the transact method should be easy to use.