### PR TITLE
RangeOption from RangeInclusive

### DIFF
--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -309,6 +309,23 @@ impl<'a> Into<RangeOption<'a>> for std::ops::Range<&'a [u8]> {
         RangeOption::from((self.start, self.end))
     }
 }
+impl Into<RangeOption<'static>> for std::ops::Range<Vec<u8>> {
+    fn into(self) -> RangeOption<'static> {
+        RangeOption::from((self.start, self.end))
+    }
+}
+impl<'a> Into<RangeOption<'a>> for std::ops::RangeInclusive<&'a [u8]> {
+    fn into(self) -> RangeOption<'a> {
+        let (start, end) = self.into_inner();
+        (KeySelector::first_greater_or_equal(start)..KeySelector::first_greater_than(end)).into()
+    }
+}
+impl Into<RangeOption<'static>> for std::ops::RangeInclusive<Vec<u8>> {
+    fn into(self) -> RangeOption<'static> {
+        let (start, end) = self.into_inner();
+        (KeySelector::first_greater_or_equal(start)..KeySelector::first_greater_than(end)).into()
+    }
+}
 
 impl Transaction {
     pub(crate) fn new(inner: NonNull<fdb_sys::FDBTransaction>) -> Self {


### PR DESCRIPTION
This tests various ways to build a RangeOption and add impl Into<RangeOption> for RangeInclusive<...>.

This allow to use the start..=end rust syntax to build a RangeOption.

Resolves #129.
