### PR TITLE
Add support for pack with versionstamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --target x86_64-unknown-linux-gnu
+          # doc tests are disabled fow now as they do not compile with -Cpanic=abort
+          args: --tests --no-fail-fast --target x86_64-unknown-linux-gnu
 
       - name: Run bindingtester
         run: scripts/run_bindingtester.sh target/x86_64-unknown-linux-gnu/debug/bindingtester

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
 
     env:
       CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
 
     steps:
       - name: Checkout repository
@@ -165,6 +166,11 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
 
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUST_BACKTRACE: 1
+      RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+
     steps:
       - uses: actions/checkout@v1
 
@@ -181,24 +187,15 @@ jobs:
         with:
           command: build
           args: -p bindingtester --target x86_64-unknown-linux-gnu
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --no-fail-fast --target x86_64-unknown-linux-gnu
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUST_BACKTRACE: 1
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
 
       - name: Run bindingtester
         run: scripts/run_bindingtester.sh target/x86_64-unknown-linux-gnu/debug/bindingtester
-        env:
-          RUST_BACKTRACE: 1
 
       - id: coverage
         uses: actions-rs/grcov@v0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          command: test
-          args: --manifest-path foundationdb/Cargo.toml --no-default-features --features fdb-6_1 --tests
           args: -p bindingtester
 
       - name: Run bindingtester

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+          command: test
+          args: --manifest-path foundationdb/Cargo.toml --no-default-features --features fdb-6_1 --tests
           args: -p bindingtester
 
       - name: Run bindingtester
@@ -195,6 +197,8 @@ jobs:
 
       - name: Run bindingtester
         run: scripts/run_bindingtester.sh target/x86_64-unknown-linux-gnu/debug/bindingtester
+        env:
+          RUST_BACKTRACE: 1
 
       - id: coverage
         uses: actions-rs/grcov@v0.1

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -19,9 +19,19 @@ categories = ["database"]
 
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["fdb-6_1"]
+# Use the locally embedded foundationdb fdb_c.h and fdb.options files
+embedded-fdb-include = [ "foundationdb/embedded-fdb-include" ]
+fdb-5_1 = [ "foundationdb/fdb-5_1" ]
+fdb-5_2 = [ "foundationdb/fdb-5_2" ]
+fdb-6_0 = [ "foundationdb/fdb-6_0" ]
+fdb-6_1 = [ "foundationdb/fdb-6_1" ]
+fdb-6_2 = [ "foundationdb/fdb-6_2" ]
+
 [dependencies]
 env_logger = "0.7.1"
-foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint"] }
+foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint"], default-features = false  }
 foundationdb-sys = { version = "0.5.0", path = "../foundationdb-sys", default-features = false }
 futures = "0.3.0"
 log = "0.4.8"

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -25,4 +25,5 @@ foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint"] }
 foundationdb-sys = { version = "0.5.0", path = "../foundationdb-sys", default-features = false }
 futures = "0.3.0"
 log = "0.4.8"
+num-bigint = "0.2.6"
 structopt = "0.3.3"

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -25,5 +25,5 @@ foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint"] }
 foundationdb-sys = { version = "0.5.0", path = "../foundationdb-sys", default-features = false }
 futures = "0.3.0"
 log = "0.4.8"
-num-bigint = "0.2.6"
+num-bigint = "0.3.0"
 structopt = "0.3.3"

--- a/foundationdb-bindingtester/Cargo.toml
+++ b/foundationdb-bindingtester/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 env_logger = "0.7.1"
-foundationdb = { path = "../foundationdb", features = ["uuid"] }
+foundationdb = { path = "../foundationdb", features = ["uuid", "num-bigint"] }
 foundationdb-sys = { version = "0.5.0", path = "../foundationdb-sys", default-features = false }
 futures = "0.3.0"
 log = "0.4.8"

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -681,11 +681,10 @@ impl StackMachine {
             // pushes the difference (A-B) onto the stack.
             // A and B may be assumed to be integers.
             Sub => {
-                let a: i64 = self.pop_item().await;
-                let b: i64 = self.pop_item().await;
+                let a: num_bigint::BigInt = self.pop_item().await;
+                let b: num_bigint::BigInt = self.pop_item().await;
                 debug!("sub {:?} - {:?}", a, b);
-                // wrapping sub to match bindingtester expected output
-                self.push_item(number, &(a.wrapping_sub(b)));
+                self.push_item(number, &(a - b));
             }
             // Pops the top two items off the stack as A and B and then pushes
             // the concatenation of A and B onto the stack. A and B can be

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -233,7 +233,7 @@ impl Instr {
             "WAIT_FUTURE" => WaitFuture,
 
             "TUPLE_PACK" => TuplePack,
-            "TUPKE_PACK_WITH_VERSONSTAMP" => TuplePackWithVersionstamp,
+            "TUPLE_PACK_WITH_VERSONSTAMP" => TuplePackWithVersionstamp,
             "TUPLE_UNPACK" => TupleUnpack,
             "TUPLE_RANGE" => TupleRange,
             "TUPLE_SORT" => TupleSort,

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -233,7 +233,7 @@ impl Instr {
             "WAIT_FUTURE" => WaitFuture,
 
             "TUPLE_PACK" => TuplePack,
-            "TUPLE_PACK_WITH_VERSONSTAMP" => TuplePackWithVersionstamp,
+            "TUPLE_PACK_WITH_VERSIONSTAMP" => TuplePackWithVersionstamp,
             "TUPLE_UNPACK" => TupleUnpack,
             "TUPLE_RANGE" => TupleRange,
             "TUPLE_SORT" => TupleSort,

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -1198,11 +1198,18 @@ impl StackMachine {
             // limits, so these bindings can obtain different sizes back.
             GetApproximateSize => {
                 debug!("get_approximate_size");
-                trx.as_mut()
-                    .get_approximate_size()
-                    .await
-                    .expect("failed to get approximate size");
-                self.push(number, GOT_APPROXIMATE_SIZE.clone().into_owned());
+                #[cfg(feature = "fdb-6_2")]
+                {
+                    trx.as_mut()
+                        .get_approximate_size()
+                        .await
+                        .expect("failed to get approximate size");
+                    self.push(number, GOT_APPROXIMATE_SIZE.clone().into_owned());
+                }
+                #[cfg(not(feature = "fdb-6_2"))]
+                {
+                    unimplemented!("get_approximate_size requires fdb620+");
+                }
             }
 
             // Pops the top item off the stack and pushes it back on. If the top item on

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -6,18 +6,26 @@ use foundationdb_sys as fdb_sys;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::io::Write;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::thread;
 
 use fdb::options::{ConflictRangeType, DatabaseOption, TransactionOption};
-use fdb::tuple::{pack, pack_into, unpack, Bytes, Element, Subspace, TuplePack, TupleUnpack};
+use fdb::tuple::{pack, pack_into, unpack, Bytes, Element, Subspace, TuplePack};
 use fdb::*;
 use futures::future;
 use futures::prelude::*;
 
-static RESULT_NOT_PRESENT: Bytes = Bytes(Cow::Borrowed(b"RESULT_NOT_PRESENT"));
+static WAITED_FOR_EMPTY: Element = Element::Bytes(Bytes(Cow::Borrowed(b"WAITED_FOR_EMPTY")));
+static RESULT_NOT_PRESENT: Element = Element::Bytes(Bytes(Cow::Borrowed(b"RESULT_NOT_PRESENT")));
+static GOT_READ_VERSION: Element = Element::Bytes(Bytes(Cow::Borrowed(b"GOT_READ_VERSION")));
+static GOT_COMMITTED_VERSION: Element =
+    Element::Bytes(Bytes(Cow::Borrowed(b"GOT_COMMITTED_VERSION")));
+static ERROR_NONE: Element = Element::Bytes(Bytes(Cow::Borrowed(b"ERROR: NONE")));
+static ERROR_MULTIPLE: Element = Element::Bytes(Bytes(Cow::Borrowed(b"ERROR: MULTIPLE")));
+static OK: Element = Element::Bytes(Bytes(Cow::Borrowed(b"OK")));
 
 use crate::fdb::options::{MutationType, StreamingMode};
 fn mutation_from_str(s: &str) -> MutationType {
@@ -123,7 +131,7 @@ impl Instr {
 #[derive(Debug)]
 enum InstrCode {
     // data operations
-    Push(Vec<u8>),
+    Push(Element<'static>),
     Dup,
     EmptyStack,
     Swap,
@@ -198,7 +206,7 @@ impl Instr {
         let (cmd, selector) = has_opt(cmd, "_SELECTOR");
 
         let code = match cmd {
-            "PUSH" => Push(pack(&tup[1])),
+            "PUSH" => Push(tup[1].clone().into_owned()),
             "DUP" => Dup,
             "EMPTY_STACK" => EmptyStack,
             "SWAP" => Swap,
@@ -261,7 +269,7 @@ impl Instr {
 
 struct StackResult {
     state: Option<(Bytes<'static>, TransactionState)>,
-    data: FdbResult<Vec<u8>>,
+    data: FdbResult<Element<'static>>,
 }
 impl From<FdbError> for StackResult {
     fn from(err: FdbError) -> Self {
@@ -271,8 +279,8 @@ impl From<FdbError> for StackResult {
         }
     }
 }
-impl From<Vec<u8>> for StackResult {
-    fn from(data: Vec<u8>) -> Self {
+impl From<Element<'static>> for StackResult {
+    fn from(data: Element<'static>) -> Self {
         StackResult {
             state: None,
             data: Ok(data),
@@ -280,8 +288,8 @@ impl From<Vec<u8>> for StackResult {
     }
 }
 
-impl From<FdbResult<Vec<u8>>> for StackResult {
-    fn from(data: FdbResult<Vec<u8>>) -> Self {
+impl From<FdbResult<Element<'static>>> for StackResult {
+    fn from(data: FdbResult<Element<'static>>) -> Self {
         StackResult { state: None, data }
     }
 }
@@ -289,7 +297,7 @@ impl From<FdbResult<Vec<u8>>> for StackResult {
 type StackFuture = Pin<Box<dyn Future<Output = StackResult>>>;
 struct StackItem {
     number: usize,
-    data: Option<Vec<u8>>,
+    data: Option<Element<'static>>,
     fut: Option<(usize, StackFuture)>,
 }
 
@@ -319,7 +327,7 @@ impl StackItem {
                     Bytes::from(b"ERROR".as_ref()),
                     Bytes::from(format!("{}", err.code()).into_bytes()),
                 ));
-                pack(&Bytes::from(packed))
+                Element::Bytes(packed.into())
             });
 
             self.data = Some(data);
@@ -347,18 +355,16 @@ impl std::fmt::Debug for StackItem {
     }
 }
 
-fn range(bytes: Bytes) -> (Bytes<'static>, Bytes<'static>) {
-    let mut begin = bytes.into_owned();
-    let mut end = begin.clone();
-
-    begin.push(0x00);
-    end.push(0xff);
+fn range(prefix: Bytes) -> (Bytes<'static>, Bytes<'static>) {
+    let begin = prefix.clone().into_owned();
+    let end = strinc(prefix).into_owned();
 
     (begin.into(), end.into())
 }
 
 enum TransactionState {
     Transaction(Transaction),
+    TransactionCancelled(TransactionCancelled),
     TransactionCommitted(TransactionCommitted),
     TransactionCommitError(TransactionCommitError),
     Pending(usize),
@@ -370,6 +376,7 @@ impl std::fmt::Debug for TransactionState {
 
         match self {
             S::Transaction(..) => "Transaction",
+            S::TransactionCancelled(..) => "TransactionCancelled",
             S::TransactionCommitted(..) => "TransactionCommitted",
             S::TransactionCommitError(..) => "TransactionCommitError",
             S::Pending(..) => "Pending",
@@ -392,9 +399,14 @@ impl TransactionState {
     fn as_mut(&mut self) -> &mut Transaction {
         use TransactionState as S;
 
+        println!("as_mut {:?}", self);
         self.reset();
         match *self {
             S::Transaction(ref mut tr) => tr,
+            S::TransactionCancelled(ref mut tr) => unsafe {
+                // rust binding prevent accessing cancelled transaction
+                std::mem::transmute(tr)
+            },
             _ => panic!("transaction is owned by a future that is still not done"),
         }
     }
@@ -402,11 +414,19 @@ impl TransactionState {
     fn take(&mut self, id: usize) -> Transaction {
         use TransactionState as S;
 
+        println!("take {:?}", self);
         self.reset();
         match std::mem::replace(self, S::Dead) {
             S::Transaction(tr) => {
                 *self = S::Pending(id);
                 tr
+            }
+            S::TransactionCancelled(tr) => {
+                *self = S::Pending(id);
+                unsafe {
+                    // rust binding prevent accessing cancelled transaction
+                    std::mem::transmute(tr)
+                }
             }
             _ => panic!("transaction is owned by a future that is still not done"),
         }
@@ -497,40 +517,47 @@ impl StackMachine {
         item
     }
 
-    async fn pop_item<S>(&mut self) -> S
-    where
-        S: for<'de> TupleUnpack<'de>,
-    {
-        let data = self.pop_data().await;
-        match unpack(&data) {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("failed to decode item {:?}: {:?}", Bytes::from(data), e);
-            }
+    async fn maybe_pop(&mut self) -> Option<StackItem> {
+        let mut item = self.stack.pop()?;
+        if let Some((name, state)) = item.await_fut().await {
+            self.transactions.insert(name, state);
+        }
+        Some(item)
+    }
+
+    async fn pop_i64(&mut self) -> i64 {
+        let element = self.pop_element().await;
+        match element {
+            Element::Int(v) => v,
+            _ => panic!("i64 was expected, found {:?}", element),
+        }
+    }
+
+    async fn pop_i32(&mut self) -> i32 {
+        i32::try_from(self.pop_i64().await).expect("i64 to fit in i32")
+    }
+
+    async fn pop_usize(&mut self) -> usize {
+        usize::try_from(self.pop_i64().await).expect("i64 to fit in usize")
+    }
+
+    async fn pop_str(&mut self) -> String {
+        let element = self.pop_element().await;
+        match element {
+            Element::String(v) => v.into_owned(),
+            _ => panic!("string was expected, found {:?}", element),
         }
     }
 
     async fn pop_bytes(&mut self) -> Bytes<'static> {
-        let data = self.pop_data().await;
-        match unpack::<Bytes>(&data) {
-            Ok(v) => Bytes::from(v.into_owned()),
-            Err(e) => {
-                panic!("failed to decode bytes {:?}: {:?}", Bytes::from(data), e);
-            }
+        let element = self.pop_element().await;
+        match element {
+            Element::Bytes(v) => v,
+            _ => panic!("bytes were expected, found {:?}", element),
         }
     }
 
     async fn pop_element(&mut self) -> Element<'static> {
-        let data = self.pop_data().await;
-        match unpack::<Element>(&data) {
-            Ok(v) => v.into_owned(),
-            Err(e) => {
-                panic!("failed to decode element {:?}: {:?}", Bytes::from(data), e);
-            }
-        }
-    }
-
-    async fn pop_data(&mut self) -> Vec<u8> {
         let item = self.pop().await;
         if let Some(data) = item.data {
             return data;
@@ -540,21 +567,13 @@ impl StackMachine {
 
     async fn pop_selector(&mut self) -> KeySelector<'static> {
         let key: Bytes = self.pop_bytes().await;
-        let or_equal: i32 = self.pop_item().await;
-        let offset: i32 = self.pop_item().await;
+        let or_equal: i32 = i32::try_from(self.pop_i64().await).unwrap();
+        let offset: i32 = i32::try_from(self.pop_i64().await).unwrap();
 
         KeySelector::new(key.0, or_equal != 0, offset)
     }
 
-    fn push_item<S>(&mut self, number: usize, s: &S)
-    where
-        S: TuplePack,
-    {
-        let data = pack(s);
-        self.push(number, data);
-    }
-
-    fn push(&mut self, number: usize, data: Vec<u8>) {
+    fn push(&mut self, number: usize, data: Element<'static>) {
         self.stack.push(StackItem {
             number,
             data: Some(data),
@@ -573,18 +592,18 @@ impl StackMachine {
 
     fn push_res(&mut self, number: usize, res: FdbResult<()>, ok_str: &[u8]) {
         match res {
-            Ok(..) => self.push_item(number, &Bytes::from(ok_str)),
+            Ok(..) => self.push(number, Element::Bytes(ok_str.to_vec().into())),
             Err(err) => self.push_err(number, err),
         }
     }
 
     fn push_err(&mut self, number: usize, err: FdbError) {
         trace!("ERROR {:?}", err);
-        let packed = pack(&(
-            Bytes::from(b"ERROR".as_ref()),
-            Bytes::from(format!("{}", err.code()).into_bytes()),
-        ));
-        self.push_item(number, &Bytes::from(packed));
+        let packed = pack(&Element::Tuple(vec![
+            Element::Bytes(Bytes::from(b"ERROR".as_ref())),
+            Element::Bytes(Bytes::from(format!("{}", err.code()).into_bytes())),
+        ]));
+        self.push(number, Element::Bytes(packed.into()));
     }
 
     fn check<T>(&mut self, number: usize, r: FdbResult<T>) -> Result<T, ()> {
@@ -636,18 +655,15 @@ impl StackMachine {
 
         match instr.code {
             // Pushes the provided item onto the stack.
-            Push(ref data) => {
-                debug!("push {:?}", Bytes::from(data.as_slice()));
-                self.push(number, data.clone())
+            Push(ref element) => {
+                debug!("push {:?}", element);
+                self.push(number, element.clone())
             }
             // Duplicates the top item on the stack. The instruction number for
             // the duplicate item should be the same as the original.
             Dup => {
                 let top = self.pop().await;
-                debug!(
-                    "dup {:?}",
-                    Bytes::from(top.data.as_ref().unwrap().as_slice())
-                );
+                debug!("dup {:?}", top);
                 self.stack.push(top.clone());
                 self.stack.push(top);
             }
@@ -660,7 +676,7 @@ impl StackMachine {
             // Swaps the items in the stack at depth 0 and depth INDEX.
             // Does not modify the instruction numbers of the swapped items.
             Swap => {
-                let depth: usize = self.pop_item().await;
+                let depth: usize = self.pop_usize().await;
                 assert!(
                     depth < self.stack.len(),
                     "swap index invalid {} >= {}",
@@ -681,33 +697,41 @@ impl StackMachine {
             // pushes the difference (A-B) onto the stack.
             // A and B may be assumed to be integers.
             Sub => {
-                let a: num_bigint::BigInt = self.pop_item().await;
-                let b: num_bigint::BigInt = self.pop_item().await;
+                let a = self.pop_element().await;
+                let b = self.pop_element().await;
                 debug!("sub {:?} - {:?}", a, b);
-                self.push_item(number, &(a - b));
+                let c = match (a, b) {
+                    (Element::Int(a), Element::Int(b)) => Element::Int(a - b),
+                    (Element::Float(a), Element::Float(b)) => Element::Float(a - b),
+                    (Element::Double(a), Element::Double(b)) => Element::Double(a - b),
+                    (Element::BigInt(a), Element::BigInt(b)) => Element::BigInt(a - b),
+                    (Element::Int(a), Element::BigInt(b)) => Element::BigInt(a - b),
+                    (Element::BigInt(a), Element::Int(b)) => Element::BigInt(a - b),
+                    (a, b) => panic!("sub between invalid elements {:?} {:?}", a, b),
+                };
+                self.push(number, c);
             }
             // Pops the top two items off the stack as A and B and then pushes
             // the concatenation of A and B onto the stack. A and B can be
             // assumed to be of the same type and will be either byte strings or
             // unicode strings.
             Concat => {
-                let a = self.pop_data().await;
-                let b = self.pop_data().await;
-                debug!(
-                    "concat {:?} {:?}",
-                    Bytes::from(a.as_slice()),
-                    Bytes::from(b.as_slice())
-                );
-                if let (Ok(a), Ok(b)) = (unpack::<Bytes>(&a), unpack::<Bytes>(&b)) {
-                    let mut bytes = Vec::new();
-                    bytes.extend_from_slice(&a);
-                    bytes.extend_from_slice(&b);
-                    self.push_item(number, &Bytes::from(bytes));
-                } else if let (Ok(a), Ok(b)) = (unpack::<String>(&a), unpack::<String>(&b)) {
-                    self.push_item(number, &format!("{}{}", a, b));
-                } else {
-                    panic!("failed to decode item {:?} {:?}", a, b);
-                }
+                let a = self.pop_element().await;
+                let b = self.pop_element().await;
+                debug!("concat {:?} {:?}", a, b);
+                let c = match (a, b) {
+                    (Element::String(a), Element::String(b)) => {
+                        Element::String(format!("{}{}", a, b).into())
+                    }
+                    (Element::Bytes(a), Element::Bytes(b)) => {
+                        let mut bytes = Vec::new();
+                        bytes.extend_from_slice(&a);
+                        bytes.extend_from_slice(&b);
+                        Element::Bytes(bytes.into())
+                    }
+                    (a, b) => panic!("concat between invalid elements {:?} {:?}", a, b),
+                };
+                self.push(number, c);
             }
             // Pops the top item off the stack as PREFIX. Using a new
             // transaction with normal retry logic, inserts a key-value pair
@@ -726,8 +750,21 @@ impl StackMachine {
             // large, it may be necessary to commit the transaction every so often (e.g.
             // after every 100 sets) to avoid past_version errors.
             LogStack => {
-                let _prefix: Bytes = self.pop_bytes().await;
-                // TODO
+                let prefix: Bytes = self.pop_bytes().await;
+                let mut stack_idx = self.stack.len();
+                let trx_id = self.next_trx_id();
+                let mut t = trx.take(trx_id);
+                while let Some(stack_item) = self.maybe_pop().await {
+                    stack_idx -= 1;
+                    let mut key = prefix.clone().into_owned();
+                    stack_idx.pack_into_vec(&mut key);
+                    stack_item.number.pack_into_vec(&mut key);
+
+                    let value = pack(&stack_item.data.unwrap());
+                    t.set(&key, &value[..value.len().min(40000)]);
+                    t = t.commit().await.unwrap().reset();
+                }
+                trx = TransactionState::Transaction(t);
             }
 
             // Creates a new transaction and stores it in the global transaction map
@@ -736,6 +773,12 @@ impl StackMachine {
                 let name = self.cur_transaction.clone();
                 debug!("create_trx {:?}", name);
                 let trx = self.check(number, db.create_trx())?;
+                trx.set_option(fdb::options::TransactionOption::DebugTransactionIdentifier(
+                    "RUST".to_string(),
+                ))
+                .unwrap();
+                trx.set_option(fdb::options::TransactionOption::LogTransaction)
+                    .unwrap();
                 self.transactions
                     .insert(name, TransactionState::Transaction(trx));
             }
@@ -761,7 +804,7 @@ impl StackMachine {
             // stack.
             OnError => {
                 let trx_name = trx_name.cloned();
-                let error_code: i32 = self.pop_item().await;
+                let error_code: i32 = self.pop_i32().await;
                 let error = FdbError::from_code(error_code);
                 debug!("on_error {:?}", error);
                 let trx_id = self.next_trx_id();
@@ -771,7 +814,7 @@ impl StackMachine {
                     .map(|res| match res {
                         Ok(trx) => StackResult {
                             state: trx_name.map(|n| (n, TransactionState::Transaction(trx))),
-                            data: Ok(pack(&RESULT_NOT_PRESENT)),
+                            data: Ok(RESULT_NOT_PRESENT.clone().into_owned()),
                         },
                         Err(err) => StackResult::from(err),
                     })
@@ -790,8 +833,8 @@ impl StackMachine {
                     .as_mut()
                     .get(&key, instr.pop_snapshot())
                     .map_ok(|v| match v {
-                        Some(v) => pack(&Bytes::from(v.as_ref())),
-                        None => pack(&RESULT_NOT_PRESENT),
+                        Some(v) => Element::Bytes(v.to_vec().into()),
+                        None => RESULT_NOT_PRESENT.clone().into_owned(),
                     })
                     .map(StackResult::from)
                     .boxed_local();
@@ -815,14 +858,15 @@ impl StackMachine {
                     .get_key(&selector, instr.pop_snapshot())
                     .map_ok(|key| {
                         let key = Bytes::from(key.as_ref());
-                        if key.starts_with(&prefix) {
-                            pack(&key)
+                        let bytes = if key.starts_with(&prefix) {
+                            key
                         } else if key < prefix {
-                            pack(&prefix)
+                            prefix
                         } else {
                             assert!(key > prefix);
-                            pack(&strinc(prefix))
-                        }
+                            strinc(prefix)
+                        };
+                        Element::Bytes(bytes.to_vec().into())
                     })
                     .map(StackResult::from)
                     .boxed_local();
@@ -856,7 +900,6 @@ impl StackMachine {
                 let starts_with = instr.pop_starts_with();
                 let snapshot = instr.pop_snapshot();
 
-                let trx_name = trx_name.cloned();
                 let (begin, end) = if starts_with {
                     let begin: Bytes = self.pop_bytes().await;
                     let end = strinc(begin.clone());
@@ -877,13 +920,19 @@ impl StackMachine {
                     )
                 };
 
-                let limit: i64 = self.pop_item().await;
-                let reverse: i64 = self.pop_item().await;
-                let streaming_mode: i32 = self.pop_item().await;
+                let limit: i64 = self.pop_i64().await;
+                let reverse: i64 = self.pop_i64().await;
+                let streaming_mode: i32 = self.pop_i32().await;
                 let mode = streaming_from_value(streaming_mode);
                 debug!(
-                    "get_range begin={:?}, end={:?}, limit={:?}, rev={:?}, mode={:?}",
-                    begin, end, limit, reverse, mode
+                    "get_range begin={:?}\n, begin={:?}\n, end={:?}\n,end={:?}\n, limit={:?}, rev={:?}, mode={:?}",
+                    begin,
+                    unpack::<Element>(&begin.key()),
+                    end,
+                    unpack::<Element>(&end.key()),
+                    limit,
+                    reverse,
+                    mode
                 );
 
                 let prefix: Option<Bytes> = if selector {
@@ -903,40 +952,31 @@ impl StackMachine {
                     reverse: reverse != 0,
                     ..RangeOption::default()
                 };
-                async fn get_range(
-                    trx: Transaction,
-                    trx_name: Option<Bytes<'static>>,
-                    prefix: Option<Bytes<'static>>,
-                    opt: RangeOption<'static>,
-                    snapshot: bool,
-                ) -> StackResult {
-                    let res = trx
-                        .get_ranges(opt, snapshot)
-                        .try_fold(Vec::new(), move |mut out, kvs| {
-                            for kv in kvs.iter() {
-                                let key = kv.key();
-                                let value = kv.value();
-                                debug!(" - {:?} {:?}", Bytes::from(key), Bytes::from(value));
-                                if let Some(ref prefix) = prefix {
-                                    if !key.starts_with(prefix) {
-                                        continue;
-                                    }
+
+                let res = trx
+                    .as_mut()
+                    .get_ranges(opt, snapshot)
+                    .try_fold(Vec::new(), move |mut out, kvs| {
+                        for kv in kvs.iter() {
+                            let key = kv.key();
+                            let value = kv.value();
+                            debug!(" - {:?} {:?}", Bytes::from(key), Bytes::from(value));
+                            if let Some(ref prefix) = prefix {
+                                if !key.starts_with(prefix) {
+                                    continue;
                                 }
-                                pack_into(&Bytes::from(key), &mut out);
-                                pack_into(&Bytes::from(value), &mut out);
                             }
-                            future::ok(out)
-                        })
-                        .await;
-                    StackResult {
-                        state: trx_name.map(|n| (n, TransactionState::Transaction(trx))),
-                        data: res.map(|data| pack(&Bytes::from(data))),
-                    }
+                            pack_into(&Bytes::from(key), &mut out);
+                            pack_into(&Bytes::from(value), &mut out);
+                        }
+                        future::ok(out)
+                    })
+                    .map_ok(|data| Element::Bytes(data.into()))
+                    .await;
+                match res {
+                    Err(err) => self.push_err(number, err),
+                    Ok(element) => self.push(number, element),
                 }
-                let trx_id = self.next_trx_id();
-                let f = get_range(trx.take(trx_id), trx_name, prefix, opt, snapshot).boxed_local();
-                self.push_fut(number, trx_id, f);
-                pending = true;
             }
 
             // Gets the current read version and stores it in the internal stack machine
@@ -948,7 +988,7 @@ impl StackMachine {
                 match version {
                     Ok(version) => {
                         self.last_version = version;
-                        self.push_item(number, &Bytes::from(b"GOT_READ_VERSION".as_ref()));
+                        self.push(number, GOT_READ_VERSION.clone().into_owned());
                     }
                     Err(err) => self.push_err(number, err),
                 }
@@ -959,7 +999,7 @@ impl StackMachine {
                 let f = trx
                     .as_mut()
                     .get_versionstamp()
-                    .map_ok(|v| pack(&Bytes::from(v.as_ref())))
+                    .map_ok(|v| Element::Bytes(v.to_vec().into()))
                     .map(StackResult::from)
                     .boxed_local();
                 self.push_fut(number, 0, f);
@@ -1021,7 +1061,7 @@ impl StackMachine {
             // Performs the atomic operation described by OPTYPE upon KEY with VALUE. An
             // ATOMIC_OP_DATABASE call may optionally push a future onto the stack.
             AtomicOp => {
-                let optype: String = self.pop_item().await;
+                let optype: String = self.pop_str().await;
                 let key: Bytes = self.pop_bytes().await;
                 let value: Bytes = self.pop_bytes().await;
                 debug!("atomic_op {:?} {:?} {:?}", key, value, optype);
@@ -1105,7 +1145,7 @@ impl StackMachine {
                     .map(|r| match r {
                         Ok(c) => StackResult {
                             state: trx_name.map(|n| (n, TransactionState::TransactionCommitted(c))),
-                            data: Ok(pack(&RESULT_NOT_PRESENT)),
+                            data: Ok(RESULT_NOT_PRESENT.clone().into_owned()),
                         },
                         Err(c) => {
                             let err = FdbError::from_code(c.code());
@@ -1129,7 +1169,7 @@ impl StackMachine {
             Cancel => {
                 debug!("cancel");
                 let cancelled = trx.take(0).cancel();
-                trx = TransactionState::Transaction(cancelled.reset());
+                trx = TransactionState::TransactionCancelled(cancelled);
             }
 
             // Gets the committed version from the current transaction and stores it in the
@@ -1142,11 +1182,11 @@ impl StackMachine {
                         .committed_version()
                         .expect("failed to get committed version");
                     self.last_version = last_version;
-                    self.push_item(number, &Bytes::from(b"GOT_COMMITTED_VERSION".as_ref()));
+                    self.push(number, GOT_COMMITTED_VERSION.clone().into_owned());
                 } else {
                     warn!("committed_version() called on a non commited transaction");
                     self.last_version = -1;
-                    self.push_item(number, &Bytes::from(b"GOT_COMMITTED_VERSION".as_ref()));
+                    self.push(number, GOT_COMMITTED_VERSION.clone().into_owned());
                 }
             }
 
@@ -1163,7 +1203,7 @@ impl StackMachine {
             // stack and packs them as the tuple [item0,item1,...,itemN], and then pushes
             // this single packed value onto the stack.
             TuplePack => {
-                let n: usize = self.pop_item().await;
+                let n: usize = self.pop_usize().await;
                 debug!("tuple_pack {}", n);
                 let mut buf = Vec::new();
                 for _ in 0..n {
@@ -1171,8 +1211,9 @@ impl StackMachine {
                     debug!(" - {:?}", element);
                     buf.push(element);
                 }
-                let packed = pack(&buf);
-                self.push_item(number, &Bytes::from(packed));
+                let tuple = Element::Tuple(buf);
+                debug!("tuple_packed {}", Bytes::from(pack(&tuple)));
+                self.push(number, Element::Bytes(pack(&tuple).into()));
             }
 
             // Pops the top item off of the stack as a byte string prefix. Pops the next item
@@ -1188,7 +1229,7 @@ impl StackMachine {
             // operation.)
             TuplePackWithVersionstamp => {
                 let prefix = self.pop_bytes().await;
-                let n: usize = self.pop_item().await;
+                let n: usize = self.pop_usize().await;
                 debug!("tuple_pack_with_versionstamp {:?} {}", prefix, n);
                 let mut buf = Vec::new();
                 for _ in 0..n {
@@ -1200,19 +1241,18 @@ impl StackMachine {
                 let tuple = Element::Tuple(buf);
                 let i = tuple.count_incomplete_versionstamp();
 
-                self.push_item(
+                self.push(
                     number,
-                    &Bytes::from(if i == 0 {
-                        b"ERROR: NONE".as_ref()
+                    if i == 0 {
+                        ERROR_NONE.clone().into_owned()
                     } else if i > 0 {
-                        b"ERROR: MULTIPLE".as_ref()
+                        ERROR_MULTIPLE.clone().into_owned()
                     } else {
-                        b"OK".as_ref()
-                    }),
+                        OK.clone().into_owned()
+                    },
                 );
                 if i == 1 {
-                    let packed = pack(&tuple);
-                    self.push_item(number, &Bytes::from(packed));
+                    self.push(number, Element::Bytes(pack(&tuple).into()));
                 }
             }
 
@@ -1225,7 +1265,7 @@ impl StackMachine {
                 let data: Vec<Element> = unpack(&data).unwrap();
                 for element in data {
                     debug!(" - {:?}", element);
-                    self.push_item(number, &Bytes::from(pack(&element)));
+                    self.push(number, Element::Bytes(pack(&(element,)).into()));
                 }
             }
             // Pops the top item off of the stack as N. Pops the next N items off of the
@@ -1233,24 +1273,18 @@ impl StackMachine {
             // structure) to the tuple range method. Pushes the begin and end elements of
             // the returned range onto the stack.
             TupleRange => {
-                let n: usize = self.pop_item().await;
+                let n: usize = self.pop_usize().await;
                 debug!("tuple_range {:?}", n);
                 let mut tup = Vec::new();
                 for _ in 0..n {
-                    let mut data = self.pop_data().await;
-                    tup.append(&mut data);
+                    let element = self.pop_element().await;
+                    tup.push(element);
                 }
 
-                {
-                    let mut data = tup.clone();
-                    data.push(0x00);
-                    self.push_item(number, &Bytes::from(data));
-                }
-                {
-                    let mut data = tup;
-                    data.push(0xff);
-                    self.push_item(number, &Bytes::from(data));
-                }
+                let subspace = Subspace::from(tup);
+                let (start, end) = subspace.range();
+                self.push(number, Element::Bytes(start.into()));
+                self.push(number, Element::Bytes(end.into()));
             }
 
             // Pops the top item off of the stack as N. Pops the next N items off of the
@@ -1261,16 +1295,20 @@ impl StackMachine {
             // use that to sort. Otherwise, it should sort them lexicographically by
             // their byte representation. The choice of function should not affect final sort order.
             TupleSort => {
-                let n: usize = self.pop_item().await;
+                let n: usize = self.pop_usize().await;
                 debug!("tuple_sort {:?}", n);
-                let mut tup = Vec::new();
+                let mut tup = Vec::<Element>::new();
                 for _ in 0..n {
-                    let data = self.pop_data().await;
-                    tup.push(Bytes::from(data));
+                    let packed = self.pop_bytes().await;
+                    let element: Element = unpack(&packed).unwrap();
+                    debug!("- {:?}", element);
+                    tup.push(element.into_owned());
                 }
                 tup.sort();
-                for data in tup {
-                    self.push(number, data.into_owned());
+                debug!("tuple_sorted");
+                for element in tup {
+                    debug!("- {:?}", element);
+                    self.push(number, Element::Bytes(pack(&element).into()));
                 }
             }
 
@@ -1283,7 +1321,7 @@ impl StackMachine {
                 let mut arr = [0; 4];
                 arr.copy_from_slice(&bytes);
                 let f = f32::from_bits(u32::from_be_bytes(arr));
-                self.push_item(number, &f);
+                self.push(number, Element::Float(f));
             }
             // Pops the top item off of the stack. This will be a byte-string of length 8
             // containing the IEEE 754 encoding of a double in big-endian order.
@@ -1294,25 +1332,35 @@ impl StackMachine {
                 let mut arr = [0; 8];
                 arr.copy_from_slice(&bytes);
                 let f = f64::from_bits(u64::from_be_bytes(arr));
-                self.push_item(number, &f);
+                self.push(number, Element::Double(f));
             }
             // Pops the top item off of the stack. This will be a single-precision float.
             // This is converted into a (4 byte) byte-string of its IEEE 754 representation
             // in big-endian order, and pushed onto the stack.
             DecodeFloat => {
-                let f: f32 = self.pop_item().await;
+                let f: f32 = match self.pop_element().await {
+                    Element::Float(v) => v,
+                    element => panic!("float was expected, found {:?}", element),
+                };
                 debug!("decode_float {}", f);
-                let packed = pack(&Bytes::from(f.to_bits().to_be_bytes().as_ref()));
-                self.push_item(number, &Bytes::from(packed));
+                self.push(
+                    number,
+                    Element::Bytes(f.to_bits().to_be_bytes().to_vec().into()),
+                );
             }
             // Pops the top item off of the stack. This will be a double-precision float.
             // This is converted into a (8 byte) byte-string its IEEE 754 representation
             // in big-endian order, and pushed onto the stack.
             DecodeDouble => {
-                let f: f64 = self.pop_item().await;
+                let f: f64 = match self.pop_element().await {
+                    Element::Double(v) => v,
+                    element => panic!("double was expected, found {:?}", element),
+                };
                 debug!("decode_double {}", f);
-                let packed = pack(&Bytes::from(f.to_bits().to_be_bytes().as_ref()));
-                self.push_item(number, &Bytes::from(packed));
+                self.push(
+                    number,
+                    Element::Bytes(f.to_bits().to_be_bytes().to_vec().into()),
+                );
             }
 
             // Pops the top item off of the stack as PREFIX. Creates a new stack machine
@@ -1371,7 +1419,7 @@ impl StackMachine {
                     )
                     .await;
                 self.check(number, r)?;
-                self.push_item(number, &Bytes::from(b"WAITED_FOR_EMPTY".as_ref()));
+                self.push(number, WAITED_FOR_EMPTY.clone().into_owned());
             }
 
             UnitTests => {
@@ -1434,7 +1482,7 @@ impl StackMachine {
         if is_db && mutation {
             let r = trx.take(0).commit().await.map_err(|e| e.into());
             self.check(number, r)?;
-            self.push_item(number, &RESULT_NOT_PRESENT);
+            self.push(number, RESULT_NOT_PRESENT.clone().into_owned());
         } else if !self.transactions.contains_key(&self.cur_transaction) {
             self.transactions.insert(self.cur_transaction.clone(), trx);
         }

--- a/foundationdb-bindingtester/src/main.rs
+++ b/foundationdb-bindingtester/src/main.rs
@@ -23,11 +23,14 @@ static RESULT_NOT_PRESENT: Element = Element::Bytes(Bytes(Cow::Borrowed(b"RESULT
 static GOT_READ_VERSION: Element = Element::Bytes(Bytes(Cow::Borrowed(b"GOT_READ_VERSION")));
 static GOT_COMMITTED_VERSION: Element =
     Element::Bytes(Bytes(Cow::Borrowed(b"GOT_COMMITTED_VERSION")));
-static GOT_APPROXIMATE_SIZE: Element =
-    Element::Bytes(Bytes(Cow::Borrowed(b"GOT_APPROXIMATE_SIZE")));
+
 static ERROR_NONE: Element = Element::Bytes(Bytes(Cow::Borrowed(b"ERROR: NONE")));
 static ERROR_MULTIPLE: Element = Element::Bytes(Bytes(Cow::Borrowed(b"ERROR: MULTIPLE")));
 static OK: Element = Element::Bytes(Bytes(Cow::Borrowed(b"OK")));
+
+#[cfg(feature = "fdb-6_2")]
+static GOT_APPROXIMATE_SIZE: Element =
+    Element::Bytes(Bytes(Cow::Borrowed(b"GOT_APPROXIMATE_SIZE")));
 
 use crate::fdb::options::{MutationType, StreamingMode};
 use tuple::VersionstampOffset;

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -45,7 +45,7 @@ memchr = "2.2.1"
 rand = "0.7.2"
 static_assertions = "1.1.0"
 uuid = { version = "0.8.1", optional = true }
-num-bigint = { version = "0.2.6", optional = true }
+num-bigint = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 byteorder = "1.3.2"

--- a/foundationdb/src/error.rs
+++ b/foundationdb/src/error.rs
@@ -8,7 +8,6 @@
 
 //! Error types for the Fdb crate
 
-use std;
 use std::ffi::CStr;
 use std::fmt;
 

--- a/foundationdb/src/future.rs
+++ b/foundationdb/src/future.rs
@@ -22,7 +22,6 @@
 //! important for reducing the latency of transactions.
 //!
 
-use std;
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt;

--- a/foundationdb/src/transaction.rs
+++ b/foundationdb/src/transaction.rs
@@ -26,6 +26,7 @@ use futures::{
 
 /// A committed transaction.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct TransactionCommitted {
     tr: Transaction,
 }
@@ -129,6 +130,7 @@ type TransactionResult = Result<TransactionCommitted, TransactionCommitError>;
 
 /// A cancelled transaction
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct TransactionCancelled {
     tr: Transaction,
 }

--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -1,52 +1,150 @@
+use super::pack::{f32_to_u32_be_bytes, f64_to_u64_be_bytes};
 use super::{Bytes, Versionstamp};
-use std::borrow::Cow;
+use std::{borrow::Cow, cmp};
 
-#[derive(Clone, PartialEq, Debug)]
+#[cfg(feature = "num-bigint")]
+use std::convert::TryInto;
+
+#[derive(Clone, Debug)]
 pub enum Element<'a> {
     Nil,
     Bytes(Bytes<'a>),
     String(Cow<'a, str>),
     Tuple(Vec<Element<'a>>),
     Int(i64),
+    #[cfg(feature = "num-bigint")]
+    BigInt(num_bigint::BigInt),
     Float(f32),
     Double(f64),
     Bool(bool),
-    Versionstamp(Versionstamp),
     #[cfg(feature = "uuid")]
     Uuid(uuid::Uuid),
-    #[cfg(feature = "num-bigint")]
-    BigInt(num_bigint::BigInt),
+    Versionstamp(Versionstamp),
+}
+
+struct CmpElement<'a, 'b>(&'a Element<'b>);
+
+impl<'a, 'b> PartialEq for CmpElement<'a, 'b> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == cmp::Ordering::Equal
+    }
+}
+impl<'a, 'b> Eq for CmpElement<'a, 'b> {}
+
+impl<'a, 'b> PartialOrd for CmpElement<'a, 'b> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a, 'b> Ord for CmpElement<'a, 'b> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.0
+            .code()
+            .cmp(&other.0.code())
+            .then_with(|| match (&self.0, &other.0) {
+                (Element::Bytes(a), Element::Bytes(b)) => a.cmp(b),
+                (Element::String(a), Element::String(b)) => a.cmp(b),
+                (Element::Tuple(a), Element::Tuple(b)) => {
+                    let a_values = a.iter().map(CmpElement);
+                    let b_values = b.iter().map(CmpElement);
+                    a_values.cmp(b_values)
+                }
+                (Element::Int(a), Element::Int(b)) => a.cmp(b),
+                #[cfg(feature = "num-bigint")]
+                (Element::BigInt(a), Element::BigInt(b)) => a.cmp(b),
+                (Element::Float(a), Element::Float(b)) => {
+                    f32_to_u32_be_bytes(*a).cmp(&f32_to_u32_be_bytes(*b))
+                }
+                (Element::Double(a), Element::Double(b)) => {
+                    f64_to_u64_be_bytes(*a).cmp(&f64_to_u64_be_bytes(*b))
+                }
+                #[cfg(feature = "uuid")]
+                (Element::Uuid(a), Element::Uuid(b)) => a.cmp(b),
+                (Element::Versionstamp(a), Element::Versionstamp(b)) => a.cmp(b),
+                _ => cmp::Ordering::Equal,
+            })
+    }
+}
+
+impl<'a> PartialEq for Element<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == cmp::Ordering::Equal
+    }
+}
+impl<'a> Eq for Element<'a> {}
+
+impl<'a> PartialOrd for Element<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<'a> Ord for Element<'a> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.cmp_at_root(other)
+    }
 }
 
 impl<'a> Element<'a> {
+    fn code(&self) -> u8 {
+        match self {
+            Element::Nil => super::NIL,
+            Element::Bytes(_) => super::BYTES,
+            Element::String(_) => super::STRING,
+            Element::Tuple(_) => super::NESTED,
+            Element::Int(_) => super::INTZERO,
+            #[cfg(feature = "num-bigint")]
+            Element::BigInt(_) => super::POSINTEND,
+            Element::Float(_) => super::FLOAT,
+            Element::Double(_) => super::DOUBLE,
+            Element::Bool(v) => {
+                if *v {
+                    super::TRUE
+                } else {
+                    super::FALSE
+                }
+            }
+            #[cfg(feature = "uuid")]
+            Element::Uuid(_) => super::UUID,
+            Element::Versionstamp(_) => super::VERSIONSTAMP,
+        }
+    }
+
+    #[inline]
+    fn cmp_values(&self) -> &[Self] {
+        match self {
+            Element::Tuple(v) => v.as_slice(),
+            v => std::slice::from_ref(v),
+        }
+    }
+
+    fn cmp_at_root<'b>(&self, b: &Element<'b>) -> cmp::Ordering {
+        let a_values = self.cmp_values().iter().map(CmpElement);
+        let b_values = b.cmp_values().iter().map(CmpElement);
+        a_values.cmp(b_values)
+    }
+
     pub fn into_owned(self) -> Element<'static> {
         match self {
             Element::Nil => Element::Nil,
-            Element::Bool(v) => Element::Bool(v),
-            Element::Int(v) => Element::Int(v),
-            Element::Float(v) => Element::Float(v),
-            Element::Double(v) => Element::Double(v),
-            Element::String(v) => Element::String(Cow::Owned(v.into_owned())),
             Element::Bytes(v) => Element::Bytes(v.into_owned().into()),
-            Element::Versionstamp(v) => Element::Versionstamp(v),
+            Element::String(v) => Element::String(Cow::Owned(v.into_owned())),
             Element::Tuple(v) => Element::Tuple(v.into_iter().map(|e| e.into_owned()).collect()),
-            #[cfg(feature = "uuid")]
-            Element::Uuid(v) => Element::Uuid(v),
+            Element::Int(v) => Element::Int(v),
             #[cfg(feature = "num-bigint")]
             Element::BigInt(v) => Element::BigInt(v),
+            Element::Float(v) => Element::Float(v),
+            Element::Double(v) => Element::Double(v),
+            Element::Bool(v) => Element::Bool(v),
+            #[cfg(feature = "uuid")]
+            Element::Uuid(v) => Element::Uuid(v),
+            Element::Versionstamp(v) => Element::Versionstamp(v),
         }
     }
 
-    pub fn as_bool(&self) -> Option<bool> {
-        match *self {
-            Element::Bool(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub fn as_i64(&self) -> Option<i64> {
-        match *self {
-            Element::Int(v) => Some(v),
+    pub fn as_bytes(&self) -> Option<&Bytes> {
+        match self {
+            Element::Bytes(v) => Some(v),
             _ => None,
         }
     }
@@ -58,16 +156,62 @@ impl<'a> Element<'a> {
         }
     }
 
-    pub fn as_bytes(&self) -> Option<&Bytes> {
+    pub fn as_tuple(&self) -> Option<&[Element<'a>]> {
         match self {
-            Element::Bytes(v) => Some(v),
+            Element::Tuple(v) => Some(v.as_slice()),
             _ => None,
         }
     }
 
-    pub fn as_tuple(&self) -> Option<&[Element<'a>]> {
+    pub fn as_i64(&self) -> Option<i64> {
         match self {
-            Element::Tuple(v) => Some(v.as_slice()),
+            Element::Int(v) => Some(*v),
+            #[cfg(feature = "num-bigint")]
+            Element::BigInt(v) => v.try_into().ok(),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "num-bigint")]
+    pub fn as_bigint(&self) -> Option<&num_bigint::BigInt> {
+        match self {
+            Element::BigInt(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            Element::Float(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Element::Double(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match *self {
+            Element::Bool(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "uuid")]
+    pub fn as_uuid(&self) -> Option<&uuid::Uuid> {
+        match self {
+            Element::Uuid(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_versionstamp(&self) -> Option<&Versionstamp> {
+        match self {
+            Element::Versionstamp(v) => Some(v),
             _ => None,
         }
     }

--- a/foundationdb/src/tuple/element.rs
+++ b/foundationdb/src/tuple/element.rs
@@ -11,9 +11,11 @@ pub enum Element<'a> {
     Float(f32),
     Double(f64),
     Bool(bool),
+    Versionstamp(Versionstamp),
     #[cfg(feature = "uuid")]
     Uuid(uuid::Uuid),
-    Versionstamp(Versionstamp),
+    #[cfg(feature = "num-bigint")]
+    BigInt(num_bigint::BigInt),
 }
 
 impl<'a> Element<'a> {
@@ -30,6 +32,8 @@ impl<'a> Element<'a> {
             Element::Tuple(v) => Element::Tuple(v.into_iter().map(|e| e.into_owned()).collect()),
             #[cfg(feature = "uuid")]
             Element::Uuid(v) => Element::Uuid(v),
+            #[cfg(feature = "num-bigint")]
+            Element::BigInt(v) => Element::BigInt(v),
         }
     }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -123,7 +123,9 @@ impl<'a> fmt::Display for Bytes<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "b\"")?;
         for &byte in self.0.iter() {
-            if byte.is_ascii_alphanumeric() || byte.is_ascii_punctuation() || byte == b' ' {
+            if byte == b'\\' {
+                write!(fmt, r"\\")?;
+            } else if byte.is_ascii_alphanumeric() {
                 write!(fmt, "{}", byte as char)?;
             } else {
                 write!(fmt, "\\x{:02x}", byte)?;
@@ -533,6 +535,13 @@ mod tests {
         test_serde(
             Element::Tuple(vec![Element::Nil, Element::Nil]),
             b"\x00\x00",
+        );
+        test_serde(
+            Element::Tuple(vec![
+                Element::String(Cow::Borrowed("PUSH")),
+                Element::Tuple(vec![Element::Double(-8.251343508909708e-15)]),
+            ]),
+            b"\x02PUSH\x00\x05!B\xfdkl\x9f\xcc\x8eK\x00",
         );
     }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -347,6 +347,57 @@ mod tests {
             b"\x0C\x80\x00\x00\x00\x00\x00\x00\x00",
         );
         test_serde(i64::min_value(), b"\x0C\x7f\xff\xff\xff\xff\xff\xff\xff");
+
+        test_serde(9252427359321063944i128, b"\x1c\x80g9\xa9np\x02\x08");
+        assert!(matches!(
+            unpack::<i64>(b"\x1c\x80g9\xa9np\x02\x08").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
+
+        test_serde(
+            -9252427359321063944i128,
+            b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7",
+        );
+        assert!(matches!(
+            unpack::<i64>(b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
+
+        test_serde(
+            u64::max_value() as i128,
+            b"\x1c\xff\xff\xff\xff\xff\xff\xff\xff",
+        );
+        assert!(matches!(
+            unpack::<i64>(b"\x1c\xff\xff\xff\xff\xff\xff\xff\xff").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
+
+        test_serde(
+            -(u64::max_value() as i128),
+            b"\x0c\x00\x00\x00\x00\x00\x00\x00\x00",
+        );
+        assert!(matches!(
+            unpack::<i64>(b"\x0c\x00\x00\x00\x00\x00\x00\x00\x00").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
+
+        test_serde(
+            (i64::max_value() as i128) + 1,
+            b"\x1c\x80\x00\x00\x00\x00\x00\x00\x00",
+        );
+        assert!(matches!(
+            unpack::<i64>(b"\x1c\x80\x00\x00\x00\x00\x00\x00\x00").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
+
+        test_serde(
+            (i64::min_value() as i128) - 1,
+            b"\x0c\x7f\xff\xff\xff\xff\xff\xff\xfe",
+        );
+        assert!(matches!(
+            unpack::<i64>(b"\x0c\x7f\xff\xff\xff\xff\xff\xff\xfe").unwrap_err(),
+            PackError::UnsupportedIntLength
+        ));
     }
 
     #[cfg(feature = "num-bigint")]
@@ -477,6 +528,15 @@ mod tests {
         test_serde(
             BigInt::from(i64::min_value()),
             b"\x0C\x7f\xff\xff\xff\xff\xff\xff\xff",
+        );
+
+        test_serde(
+            Element::BigInt(9252427359321063944i128.into()),
+            b"\x1c\x80g9\xa9np\x02\x08",
+        );
+        test_serde(
+            Element::BigInt((-9252427359321063944i128).into()),
+            b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7",
         );
     }
 

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -208,7 +208,10 @@ pub fn pack_into<T: TuplePack>(v: &T, output: &mut Vec<u8>) {
 ///
 /// Panics if there is multiple versionstamp present or if the encoded data size doesn't fit in `u32`.
 pub fn pack_into_with_versionstamp<T: TuplePack>(v: &T, output: &mut Vec<u8>) {
-    v.pack_into_vec_with_versionstamp(output)
+    let offset = v.pack_into_vec_with_versionstamp(output);
+    if let VersionstampOffset::MultipleIncomplete = offset {
+        panic!("pack_into_with_versionstamp does not allow multiple versionstamps");
+    }
 }
 
 /// Unpack input

--- a/foundationdb/src/tuple/mod.rs
+++ b/foundationdb/src/tuple/mod.rs
@@ -349,55 +349,67 @@ mod tests {
         test_serde(i64::min_value(), b"\x0C\x7f\xff\xff\xff\xff\xff\xff\xff");
 
         test_serde(9252427359321063944i128, b"\x1c\x80g9\xa9np\x02\x08");
-        assert!(matches!(
-            unpack::<i64>(b"\x1c\x80g9\xa9np\x02\x08").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x1c\x80g9\xa9np\x02\x08").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
 
         test_serde(
             -9252427359321063944i128,
             b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7",
         );
-        assert!(matches!(
-            unpack::<i64>(b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x0c\x7f\x98\xc6V\x91\x8f\xfd\xf7").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
 
         test_serde(
             u64::max_value() as i128,
             b"\x1c\xff\xff\xff\xff\xff\xff\xff\xff",
         );
-        assert!(matches!(
-            unpack::<i64>(b"\x1c\xff\xff\xff\xff\xff\xff\xff\xff").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x1c\xff\xff\xff\xff\xff\xff\xff\xff").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
 
         test_serde(
             -(u64::max_value() as i128),
             b"\x0c\x00\x00\x00\x00\x00\x00\x00\x00",
         );
-        assert!(matches!(
-            unpack::<i64>(b"\x0c\x00\x00\x00\x00\x00\x00\x00\x00").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x0c\x00\x00\x00\x00\x00\x00\x00\x00").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
 
         test_serde(
             (i64::max_value() as i128) + 1,
             b"\x1c\x80\x00\x00\x00\x00\x00\x00\x00",
         );
-        assert!(matches!(
-            unpack::<i64>(b"\x1c\x80\x00\x00\x00\x00\x00\x00\x00").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x1c\x80\x00\x00\x00\x00\x00\x00\x00").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
 
         test_serde(
             (i64::min_value() as i128) - 1,
             b"\x0c\x7f\xff\xff\xff\xff\xff\xff\xfe",
         );
-        assert!(matches!(
-            unpack::<i64>(b"\x0c\x7f\xff\xff\xff\xff\xff\xff\xfe").unwrap_err(),
-            PackError::UnsupportedIntLength
-        ));
+        assert!(
+            match unpack::<i64>(b"\x0c\x7f\xff\xff\xff\xff\xff\xff\xfe").unwrap_err() {
+                PackError::UnsupportedIntLength => true,
+                _ => false,
+            }
+        );
     }
 
     #[cfg(feature = "num-bigint")]

--- a/foundationdb/src/tuple/pack.rs
+++ b/foundationdb/src/tuple/pack.rs
@@ -1031,7 +1031,6 @@ impl<'de> TupleUnpack<'de> for Element<'de> {
                 (input, Element::Uuid(v))
             }
             found => {
-                dbg!(Bytes::from(input));
                 return Err(PackError::BadCode {
                     found,
                     expected: None,

--- a/foundationdb/src/tuple/pack.rs
+++ b/foundationdb/src/tuple/pack.rs
@@ -12,11 +12,8 @@ pub enum VersionstampOffset {
 }
 impl std::ops::AddAssign<u32> for VersionstampOffset {
     fn add_assign(&mut self, r: u32) {
-        match self {
-            VersionstampOffset::None { size } => {
-                *size += r;
-            }
-            _ => {}
+        if let VersionstampOffset::None { size } = self {
+            *size += r;
         }
     }
 }

--- a/foundationdb/src/tuple/pack.rs
+++ b/foundationdb/src/tuple/pack.rs
@@ -914,6 +914,8 @@ impl<'a> TuplePack for Element<'a> {
             Element::Tuple(ref v) => v.pack(w, tuple_depth),
             #[cfg(feature = "uuid")]
             Element::Uuid(v) => v.pack(w, tuple_depth),
+            #[cfg(feature = "num-bigint")]
+            Element::BigInt(v) => v.pack(w, tuple_depth),
         }
     }
 }
@@ -950,10 +952,22 @@ impl<'de> TupleUnpack<'de> for Element<'de> {
                 let (input, v) = i64::unpack(input, tuple_depth)?;
                 (input, Element::Int(v))
             }
+            #[cfg(feature = "num-bigint")]
+            NEGINTSTART => {
+                let (input, v) = num_bigint::BigInt::unpack(input, tuple_depth)?;
+                (input, Element::BigInt(v))
+            }
+            #[cfg(feature = "num-bigint")]
+            POSINTEND => {
+                let (input, v) = num_bigint::BigInt::unpack(input, tuple_depth)?;
+                (input, Element::BigInt(v))
+            }
+            #[cfg(not(feature = "num-bigint"))]
             NEGINTSTART => {
                 let (input, v) = i64::unpack(input, tuple_depth)?;
                 (input, Element::Int(v))
             }
+            #[cfg(not(feature = "num-bigint"))]
             POSINTEND => {
                 let (input, v) = i64::unpack(input, tuple_depth)?;
                 (input, Element::Int(v))

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -34,5 +34,6 @@ esac
   'rust': Tester('rust', '${bindingtester}', 2040, 23, MAX_API_VERSION, types=ALL_TYPES),
 }" >> ./bindings/bindingtester/known_testers.py
   ./bindings/bindingtester/bindingtester.py --test-name scripted rust
-  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --test-name api --api-version 610 rust
+  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 610 --test-name api --compare  rust
+  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 610 --test-name api --concurrency 5 rust
 )

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -30,8 +30,9 @@ esac
   make fdb_python
 
   ## Run the test
-  ./bindings/bindingtester/bindingtester.py --test-name scripted ${bindingtester}
-  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --test-name api --api-version 610 ${bindingtester}
-  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --concurrency 5 --test-name api --api-version 610 ${bindingtester}
-  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --concurrency 5 --test-name tuple --api-version 610 ${bindingtester}
+  echo "testers = {
+  'rust': Tester('rust', '${bindingtester}', 2040, 23, MAX_API_VERSION, types=ALL_TYPES),
+}" >> ./bindings/bindingtester/known_testers.py
+  ./bindings/bindingtester/bindingtester.py --test-name scripted rust
+  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --test-name api --api-version 610 rust
 )

--- a/scripts/run_bindingtester.sh
+++ b/scripts/run_bindingtester.sh
@@ -30,10 +30,9 @@ esac
   make fdb_python
 
   ## Run the test
-  echo "testers = {
-  'rust': Tester('rust', '${bindingtester}', 2040, 23, MAX_API_VERSION, types=ALL_TYPES),
-}" >> ./bindings/bindingtester/known_testers.py
+  echo "testers['rust'] = Tester('rust', '${bindingtester}', 2040, 23, MAX_API_VERSION, types=ALL_TYPES)
+" >> ./bindings/bindingtester/known_testers.py
   ./bindings/bindingtester/bindingtester.py --test-name scripted rust
-  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 610 --test-name api --compare  rust
+  ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 610 --test-name api --compare python rust
   ./bindings/bindingtester/bindingtester.py --num-ops 1000 --api-version 610 --test-name api --concurrency 5 rust
 )


### PR DESCRIPTION
Doesn't change the packing format.
Fixes a bug in the unpacking of signed integers.
Add support for BigInt on Element
Element now implement Ord and matches the packed ordering.
Add support for packing with versionstamp
Enhance testing to match python output.


Resolves #192
Resolves #193
Resolves #195