### PR TITLE
fix broken transact() limits

### DIFF
--- a/foundationdb/src/database.rs
+++ b/foundationdb/src/database.rs
@@ -133,8 +133,8 @@ impl Database {
         let mut trx = self.create_trx()?;
         let mut can_retry = move || {
             tries += 1;
-            retry_limit.filter(|&limit| tries < limit).is_none()
-                && time_out.filter(|&t| Instant::now() < t).is_none()
+            retry_limit.filter(|&limit| tries > limit).is_none()
+                && time_out.filter(|&t| Instant::now() > t).is_none()
         };
         loop {
             let r = f.transact(trx).await;


### PR DESCRIPTION
The logic was backwards - if a retry limit is set (say 50), 1 < 50 is
true, so is_none() is false and transact() immediately aborts.