### PR TITLE
make tuple::hca::HighContentionAllocator be Send

### DIFF
--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foundationdb"
-version = "0.5.2"
+version = "0.5.1"
 authors = [
     "Benjamin Fry <benjaminfry@me.com>",
     "Vincent Rouillé <vincent@clikengo.com>",

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foundationdb"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Benjamin Fry <benjaminfry@me.com>",
     "Vincent Rouillé <vincent@clikengo.com>",
@@ -45,7 +45,7 @@ foundationdb-gen = { version = "0.5.1", path = "../foundationdb-gen", default-fe
 foundationdb-sys = { version = "0.5.1", path = "../foundationdb-sys", default-features = false }
 futures = "0.3.1"
 memchr = "2.2.1"
-rand = "0.7.2"
+rand = { version = "0.7.2", features = ["default", "small_rng"] }
 static_assertions = "1.1.0"
 uuid = { version = "0.8.1", optional = true }
 num-bigint = { version = "0.3.0", optional = true }

--- a/foundationdb/tests/hca.rs
+++ b/foundationdb/tests/hca.rs
@@ -69,9 +69,9 @@ async fn test_hca_concurrent_allocations_async() -> FdbResult<()> {
     let hca = HighContentionAllocator::new(Subspace::from_bytes(KEY));
 
     let all_ints: Vec<i64> = future::try_join_all((0..N).map(|_| {
-        db.transact_boxed_local(
+        db.transact_boxed(
             &hca,
-            move |tx, hca| hca.allocate(tx).boxed_local(),
+            move |tx, hca| hca.allocate(tx).boxed(),
             TransactOption::default(),
         )
     }))


### PR DESCRIPTION
- thread rng is not `Send`; instead, seed a `SmallRng` from it, which is `Send`
- use of allocation mutex was causing non-`Send`ability despite being dropped before any `.await` boundaries; wrapped in blocks
- update related test to use `.boxed()` instead of `.boxed_local()`